### PR TITLE
add pruned rebel-2 snapshot from september

### DIFF
--- a/guides/rebel-2-upgrade-guide.md
+++ b/guides/rebel-2-upgrade-guide.md
@@ -16,9 +16,10 @@ Please use the following network parameters to join the `rebel-2` network:
 
 - [genesis.json](https://network-rebel-2.s3.amazonaws.com/rebel-2/genesis.json)
 - [addrbook.json](https://network-rebel-2.s3.amazonaws.com/rebel-2/addrbook.json)
-- [archive snapshot (21.04.2023)](https://network-rebel-2.s3.amazonaws.com/rebel-2/archive-snapshot-21-04-2023.tar)
-- [archive snapshot (17.05.2023)](https://network-rebel-2.s3.amazonaws.com/rebel-2/archive-snapshot-17-05-2023.tar)
-- [archive snapshot (02.06.2023)](https://network-rebel-2.s3.amazonaws.com/rebel-2/archive-snapshot-02-06-2023.tar)
+- [pruned snapshot (21.04.2023)](https://network-rebel-2.s3.amazonaws.com/rebel-2/archive-snapshot-21-04-2023.tar)
+- [pruned snapshot (17.05.2023)](https://network-rebel-2.s3.amazonaws.com/rebel-2/archive-snapshot-17-05-2023.tar)
+- [pruned snapshot (02.06.2023)](https://network-rebel-2.s3.amazonaws.com/rebel-2/archive-snapshot-02-06-2023.tar)
+- [pruned snapshot (10.09.2023)](https://network-rebel-2.s3.amazonaws.com/rebel-2/snapshot-10-09-2023.tar.lz4)
 - [v2.0.1](https://github.com/classic-terra/core/archive/refs/tags/v2.0.1.tar.gz) of the `terrad` client
 - We kindly ask you to use the `main` branch of the following oracle feeder: [here](https://github.com/classic-terra/oracle-feeder)
 - for the oracle feeder please use the following version: `git checkout 81c450d36c3d64fd4d9167bc5ef8c49ce9ad104a`


### PR DESCRIPTION
Dear L1 team. I took the freedom and created a snapshot of rebel-2 network after v2.2.1 upgrade (10-09-2023). This should make it easier to onboard new testnet validators. I humbly ask you to review and merge.